### PR TITLE
include missing attr on update event

### DIFF
--- a/internal/provider/constants_test.go
+++ b/internal/provider/constants_test.go
@@ -452,7 +452,7 @@ resource "authlete_service" "complete_described" {
   encryption_alg_req_obj_match = true
   encryption_enc_alg_req_obj_match = true
   access_token_type = "Bearer"
-  tls_client_certificate_bound_access_tokens = true
+  tls_client_certificate_bound_access_tokens = false
   access_token_duration = 990
   single_access_token_per_subject = false
   access_token_sign_alg = "PS256"

--- a/internal/provider/service.go
+++ b/internal/provider/service.go
@@ -648,6 +648,14 @@ func serviceUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) 
 		srv.SetTrustAnchors(mapTrustAnchorToDTO(d.Get("trust_anchors").(*schema.Set).List(), diags))
 	}
 
+	if d.HasChange("access_token_duration") {
+		srv.SetAccessTokenDuration(int64(d.Get("access_token_duration").(int)))
+	}
+
+	if d.HasChange("tls_client_certificate_bound_access_tokens") {
+		srv.SetTlsClientCertificateBoundAccessTokens(d.Get("tls_client_certificate_bound_access_tokens").(bool))
+	}
+
 	_, _, err = client.authleteClient.ServiceManagementApi.ServiceUpdateApi(auth, d.Id()).Service(*srv).Execute()
 
 	if err != nil {

--- a/internal/provider/service_test.go
+++ b/internal/provider/service_test.go
@@ -279,7 +279,7 @@ func TestAccResourceService_update_extended(t *testing.T) {
 					resource.TestCheckResourceAttr("authlete_service.complete_described", "encryption_alg_req_obj_match", "true"),
 					resource.TestCheckResourceAttr("authlete_service.complete_described", "encryption_enc_alg_req_obj_match", "true"),
 					resource.TestCheckResourceAttr("authlete_service.complete_described", "access_token_type", "Bearer"),
-					resource.TestCheckResourceAttr("authlete_service.complete_described", "tls_client_certificate_bound_access_tokens", "true"),
+					resource.TestCheckResourceAttr("authlete_service.complete_described", "tls_client_certificate_bound_access_tokens", "false"),
 					resource.TestCheckResourceAttr("authlete_service.complete_described", "access_token_duration", "990"),
 					resource.TestCheckResourceAttr("authlete_service.complete_described", "single_access_token_per_subject", "false"),
 					resource.TestCheckResourceAttr("authlete_service.complete_described", "access_token_sign_alg", "PS256"),


### PR DESCRIPTION
the attributes below are not updated by the provider:

access_token_duration						
tls_client_certificate_bound_access_tokens			

This MR include those attributes on the update resource function