### PR TITLE
fix: client remove jwk when neither jwk or jwks is provided

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=authlete
 NAME=authlete
 BINARY=terraform-provider-${NAME}
-VERSION=1.3.14
+VERSION=1.3.17
 OS_ARCH=darwin_arm64
 OS_ARCH_AMD64=linux_amd64
 


### PR DESCRIPTION
## References
ENG-3614

## Context / Summary
This Pull Request fixes a bug where it is not possible to delete a client resource's `jwk` attribute once it is created.

The client resource supports 2 attributes corresponding to `jwk`:
- `jwks` -  a string representing the jwk
- `jwk` - json configuration block. Multiple of these can be added.

## Description / Changes Made

- Update client update logic to correctly handle case when `jwk` or `jwks` attribute in the client resource is modified.
- If `jwks` is provided, it will take priority over `jwk`
- or if `jwk` json configuration block(s) is/are provided, they will be applied
- if neither are provided, `jwk` will be cleared.


## Testing Instructions

To test the provider code locally:
1. Clone the branch
2. If using mac, create a `.terraformrc` file in your home directory (`~/`) and add the below lines. You may have to specify a different path based on your local configuration. Please see this tutorial https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider#prepare-terraform-for-local-provider-install

```
provider_installation {

  dev_overrides {
      "example.com/authlete/authlete" = "/Users/<Username>/go/bin"
  }

  # For all other providers, install them directly from their origin provider
  # registries as normal. If you omit this, Terraform will _only_ use
  # the dev_overrides block, and so no other providers will be available.
  direct {}
}
```

4. Install the provider locally by running `go install .` from the root directory of the provider code. This places an executable binary in your `GOBIN` path or in `/Users/<Username>/go/bin`.

5. In separate directory, create a `provider.tf` file and add the following:
```
terraform {
  required_providers {
    authlete = {
      source = "example.com/authlete/authlete"
      version = "1.3.99"
    }
  }
}

provider "authlete" {
  # No need to specify credentials here as they come from environment variables
}
```

6. Export the required env variables:
```
   export AUTHLETE_ORGANIZATION_ID=""
   export AUTHLETE_API_SERVER_ID="" # numerical id of the api server
   export AUTHLETE_API_VERSION="3.0"
   export AUTHLETE_SO_SECRET="" # organization access token
   export AUTHLETE_API_SERVER="http://localhost:4250" 
   export AUTHLETE_IDP_SERVER="https://localhost:5511"
   export AUTHLETE_TLS_INSECURE=true # required for local development to work with http
```

7.  Create a `main.tf` file and create a service resource
```
resource "authlete_service" "as" {
  issuer = "https://as.mydomain.com"
  service_name = "MyDomainAS"
  description = "A terraform based service for managing the Authlete based OAuth server"
  supported_grant_types = ["AUTHORIZATION_CODE"]
  supported_response_types = ["CODE"]
}

output "api_key" {
  value = authlete_service.as.id
}

output "api_secret" {
  value = authlete_service.as.api_secret
  sensitive = true
}
```

7.5 Run `go install .` from the root to install the provider locally

8. Run `terraform plan` and `terraform apply` to create the service resource.
9. Once the service resource is created, export the additional required environment variables for client creation:
```
   export AUTHLETE_API_KEY="" # the created service ID
   export AUTHLETE_SO_KEY="" # the created service ID
   export AUTHLETE_API_SECRET="" # same as the organization access token
```
10. Create a client resource by adding a client configuration with `jwk` to `main.tf`
```
resource "authlete_client" "portal" {
   client_name = "Customer Portal client"
   
   jwk {
    kty      = "RSA"
    alg      = "RS256"
    use      = "sig"
    kid      = "generated-rsa-key-01" // You can change this ID
    generate = true
    key_size = 2048
  }
}

output "client_id" {
   value = authlete_client.portal.id
}

output "client_secret" {
   value = authlete_client.portal.client_secret
   sensitive = true
}
```

11. Run `terraform plan` and `terraform apply` to create the client resource with the `jwk` property.
12. Remove the `jwk` from the client by updating it to:
```
resource "authlete_client" "portal" {
   client_name = "Customer Portal client"
}
```

13. Run `terraform plan` and `terraform apply` again. The updated client should no longer have `jwk` field.

