### PR TITLE
Update Authlete v3 SDK to v3.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.4
 require (
 	github.com/authlete/idp-api v0.0.0-20230821062417-0fad86b89106
 	github.com/authlete/openapi-for-go v1.2.3
-	github.com/authlete/openapi-for-go/v3 v3.0.0-alpha2
+	github.com/authlete/openapi-for-go/v3 v3.0.3
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/authlete/openapi-for-go v1.2.3 h1:W3fj3RNk8i4RxE8cnOQ7OQ5ai3QLBX5g7E7
 github.com/authlete/openapi-for-go v1.2.3/go.mod h1:aef7AzA/qvP2FgWZ9uevzwpjqxzRHU/0nRskl7iF3e0=
 github.com/authlete/openapi-for-go/v3 v3.0.0-alpha2 h1:Bzf0cVfrLuhXWjXplvMiSatjOoGkRszrkjrmnTqyk+Q=
 github.com/authlete/openapi-for-go/v3 v3.0.0-alpha2/go.mod h1:CS29tEKLP18ROVmBw2qYnz9Bb8aFM3Suu1o3HMdA3A8=
+github.com/authlete/openapi-for-go/v3 v3.0.3 h1:fyEI0+e95XWpzeXdYuHSlcF8hvQQ4VzH/MV7nvBbkQQ=
+github.com/authlete/openapi-for-go/v3 v3.0.3/go.mod h1:5bMIO3yjMPyTzuBSnGbdKpuxZg+axOlvAZJknNVcPFA=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -147,7 +147,7 @@ func clientCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 
 		newClientDto := dataToClient(d, diags)
 		n := newClientDto.(*authlete3.Client)
-		newOauthClient, _, err := client.authleteClient.v3.ClientManagementApi.ClientCreateApi(auth, apiKey).Client(*n).Execute()
+		newOauthClient, _, err := client.authleteClient.v3.ClientManagementAPI.ClientCreateApi(auth, apiKey).Client(*n).Execute()
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -155,8 +155,8 @@ func clientCreate(ctx context.Context, d *schema.ResourceData, meta interface{})
 		if d.Get("client_secret").(string) != "" {
 			cliSecretUpdateRequest := authlete3.ClientSecretUpdateRequest{ClientSecret: d.Get("client_secret").(string)}
 			identifier := strconv.FormatInt(newOauthClient.GetClientId(), 10)
-			updateSecretRequest := client.authleteClient.v3.ClientManagementApi.ClientSecretUpdateApi(auth,
-				identifier, apiKey)
+			updateSecretRequest := client.authleteClient.v3.ClientManagementAPI.ClientSecretUpdateApi(auth,
+				apiKey, identifier)
 
 			_, _, err := updateSecretRequest.ClientSecretUpdateRequest(cliSecretUpdateRequest).Execute()
 			if err != nil {
@@ -216,7 +216,7 @@ func clientRead(_ context.Context, d *schema.ResourceData, meta interface{}) dia
 		auth := context.WithValue(context.Background(), authlete3.ContextAccessToken, apiSecret)
 
 		identifier := getClientIdentifierForV3(d)
-		clientDto, _, err := client.authleteClient.v3.ClientManagementApi.ClientGetApi(auth, identifier, apiKey).Execute()
+		clientDto, _, err := client.authleteClient.v3.ClientManagementAPI.ClientGetApi(auth, apiKey, identifier).Execute()
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -256,13 +256,13 @@ func clientUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 		auth := context.WithValue(context.Background(), authlete3.ContextAccessToken, apiSecret)
 
 		identifier := getClientIdentifierForV3(d)
-		existingClient, _, getErr := client.authleteClient.v3.ClientManagementApi.ClientGetApi(auth, identifier, apiKey).Execute()
+		existingClient, _, getErr := client.authleteClient.v3.ClientManagementAPI.ClientGetApi(auth, apiKey, identifier).Execute()
 
 		if getErr != nil {
 			return diag.FromErr(getErr)
 		}
 		setDataToClient(d, diags, existingClient)
-		_, _, err := client.authleteClient.v3.ClientManagementApi.ClientUpdateApi(auth, identifier, apiKey).Client(*existingClient).Execute()
+		_, _, err := client.authleteClient.v3.ClientManagementAPI.ClientUpdateApi(auth, apiKey, identifier).Client(*existingClient).Execute()
 
 		if err != nil {
 			return diag.FromErr(err)
@@ -272,7 +272,7 @@ func clientUpdate(ctx context.Context, d *schema.ResourceData, meta interface{})
 		if d.HasChange("client_secret") {
 			if d.Get("client_secret").(string) != "" {
 				cliSecretUpdateRequest := authlete3.ClientSecretUpdateRequest{ClientSecret: d.Get("client_secret").(string)}
-				updateSecretRequest := client.authleteClient.v3.ClientManagementApi.ClientSecretUpdateApi(auth, identifier, apiKey)
+				updateSecretRequest := client.authleteClient.v3.ClientManagementAPI.ClientSecretUpdateApi(auth, apiKey, identifier)
 
 				_, _, err := updateSecretRequest.ClientSecretUpdateRequest(cliSecretUpdateRequest).Execute()
 
@@ -338,7 +338,7 @@ func clientDelete(_ context.Context, d *schema.ResourceData, meta interface{}) d
 		auth := context.WithValue(context.Background(), authlete3.ContextAccessToken, apiSecret)
 
 		identifier := getClientIdentifierForV3(d)
-		_, err := client.authleteClient.v3.ClientManagementApi.ClientDeleteApi(auth, identifier, apiKey).Execute()
+		_, err := client.authleteClient.v3.ClientManagementAPI.ClientDeleteApi(auth, apiKey, identifier).Execute()
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -366,7 +366,9 @@ func dataToClient(d *schema.ResourceData, diags diag.Diagnostics) IClient {
 		newClient = authlete.NewClient()
 	}
 
-	newClient.SetDeveloper(d.Get("developer").(string))
+	if !v3 {
+		newClient.(*authlete.Client).SetDeveloper(d.Get("developer").(string))
+	}
 
 	newClient.SetClientId(int64(d.Get("client_id").(int)))
 
@@ -424,7 +426,7 @@ func dataToClient(d *schema.ResourceData, diags diag.Diagnostics) IClient {
 			newClient.(*authlete3.Client).SetRequestEncryptionEnc(mapInterfaceToType[authlete3.JweEnc](d.Get("request_encryption_enc")))
 		}
 		if NotZeroString(d, "token_auth_method") {
-			newClient.(*authlete3.Client).SetTokenAuthMethod(mapInterfaceToType[authlete3.ClientAuthenticationMethod](d.Get("token_auth_method")))
+			newClient.(*authlete3.Client).SetTokenAuthMethod(mapInterfaceToType[authlete3.ClientAuthMethod](d.Get("token_auth_method")))
 		}
 		if NotZeroString(d, "token_auth_sign_alg") {
 			newClient.(*authlete3.Client).SetTokenAuthSignAlg(mapInterfaceToType[authlete3.JwsAlg](d.Get("token_auth_sign_alg")))
@@ -625,8 +627,8 @@ func dataToClient(d *schema.ResourceData, diags diag.Diagnostics) IClient {
 }
 
 func setDataToClient(d *schema.ResourceData, diags diag.Diagnostics, client IClient) {
-	if d.HasChange("developer") {
-		client.SetDeveloper(d.Get("developer").(string))
+	if !v3 && d.HasChange("developer") {
+		client.(*authlete.Client).SetDeveloper(d.Get("developer").(string))
 	}
 	if d.HasChange("client_id_alias") {
 		if v3 {
@@ -686,7 +688,11 @@ func setDataToClient(d *schema.ResourceData, diags diag.Diagnostics, client ICli
 				client.(*authlete.Client).SetApplicationType(mapInterfaceToType[authlete.ApplicationType](d.Get("application_type")))
 			}
 		} else {
-			client.SetApplicationTypeNil()
+			if v3 {
+				client.(*authlete3.Client).ApplicationType = nil
+			} else {
+				client.(*authlete.Client).SetApplicationTypeNil()
+			}
 		}
 	}
 	if d.HasChange("contacts") {
@@ -988,7 +994,7 @@ func setDataToClient(d *schema.ResourceData, diags diag.Diagnostics, client ICli
 	if d.HasChange("token_auth_method") {
 		if v3 {
 			if NotZeroString(d, "token_auth_method") {
-				client.(*authlete3.Client).SetTokenAuthMethod(mapInterfaceToType[authlete3.ClientAuthenticationMethod](d.Get("token_auth_method")))
+				client.(*authlete3.Client).SetTokenAuthMethod(mapInterfaceToType[authlete3.ClientAuthMethod](d.Get("token_auth_method")))
 			} else {
 				client.(*authlete3.Client).TokenAuthMethod = nil
 			}
@@ -1362,7 +1368,7 @@ func updateResourceFromClient(d *schema.ResourceData, client IClient) {
 		_ = d.Set("access_token_duration", clientExtension.GetAccessTokenDuration())
 		_ = d.Set("refresh_token_duration", clientExtension.GetRefreshTokenDuration())
 	} else {
-		_ = d.Set("developer", client.GetDeveloper())
+		_ = d.Set("developer", client.(*authlete.Client).GetDeveloper())
 		_ = d.Set("client_id_alias_enabled", client.GetClientIdAliasEnabled())
 		c := client.(*authlete.Client)
 		_ = d.Set("client_type", c.GetClientType())

--- a/internal/provider/interface_client.go
+++ b/internal/provider/interface_client.go
@@ -9,10 +9,6 @@ type IClient interface {
 	GetServiceNumberOk() (*int32, bool)
 	HasServiceNumber() bool
 	SetServiceNumber(v int32)
-	GetDeveloper() string
-	GetDeveloperOk() (*string, bool)
-	HasDeveloper() bool
-	SetDeveloper(v string)
 	GetClientName() string
 	GetClientNameOk() (*string, bool)
 	HasClientName() bool
@@ -41,8 +37,6 @@ type IClient interface {
 	SetClientIdAliasEnabled(v bool)
 	HasClientType() bool
 	HasApplicationType() bool
-	SetApplicationTypeNil()
-	UnsetApplicationType()
 	GetLogoUri() string
 	GetLogoUriOk() (*string, bool)
 	HasLogoUri() bool
@@ -247,10 +241,6 @@ type IClient interface {
 	GetExplicitlyRegisteredOk() (*bool, bool)
 	HasExplicitlyRegistered() bool
 	SetExplicitlyRegistered(v bool)
-	GetRsResponseSigned() bool
-	GetRsResponseSignedOk() (*bool, bool)
-	HasRsResponseSigned() bool
-	SetRsResponseSigned(v bool)
 	GetRsSignedRequestKeyId() string
 	GetRsSignedRequestKeyIdOk() (*string, bool)
 	HasRsSignedRequestKeyId() bool

--- a/internal/provider/interface_service.go
+++ b/internal/provider/interface_service.go
@@ -5,10 +5,6 @@ type IService interface {
 	GetNumberOk() (*int32, bool)
 	HasNumber() bool
 	SetNumber(v int32)
-	GetServiceOwnerNumber() int32
-	GetServiceOwnerNumberOk() (*int32, bool)
-	HasServiceOwnerNumber() bool
-	SetServiceOwnerNumber(v int32)
 	GetServiceName() string
 	GetServiceNameOk() (*string, bool)
 	HasServiceName() bool
@@ -25,14 +21,6 @@ type IService interface {
 	GetApiKeyOk() (*int64, bool)
 	HasApiKey() bool
 	SetApiKey(v int64)
-	GetApiSecret() string
-	GetApiSecretOk() (*string, bool)
-	HasApiSecret() bool
-	SetApiSecret(v string)
-	GetClientsPerDeveloper() int32
-	GetClientsPerDeveloperOk() (*int32, bool)
-	HasClientsPerDeveloper() bool
-	SetClientsPerDeveloper(v int32)
 	GetClientIdAliasEnabled() bool
 	GetClientIdAliasEnabledOk() (*bool, bool)
 	HasClientIdAliasEnabled() bool
@@ -58,25 +46,10 @@ type IService interface {
 	GetAuthenticationCallbackApiSecretOk() (*string, bool)
 	HasAuthenticationCallbackApiSecret() bool
 	SetAuthenticationCallbackApiSecret(v string)
-	HasSupportedSnses() bool
-	HasSnsCredentials() bool
 	GetSupportedAcrs() []string
 	GetSupportedAcrsOk() ([]string, bool)
 	HasSupportedAcrs() bool
 	SetSupportedAcrs(v []string)
-	GetDeveloperAuthenticationCallbackEndpoint() string
-	GetDeveloperAuthenticationCallbackEndpointOk() (*string, bool)
-	HasDeveloperAuthenticationCallbackEndpoint() bool
-	SetDeveloperAuthenticationCallbackEndpoint(v string)
-	GetDeveloperAuthenticationCallbackApiKey() string
-	GetDeveloperAuthenticationCallbackApiKeyOk() (*string, bool)
-	HasDeveloperAuthenticationCallbackApiKey() bool
-	SetDeveloperAuthenticationCallbackApiKey(v string)
-	GetDeveloperAuthenticationCallbackApiSecret() string
-	GetDeveloperAuthenticationCallbackApiSecretOk() (*string, bool)
-	HasDeveloperAuthenticationCallbackApiSecret() bool
-	SetDeveloperAuthenticationCallbackApiSecret(v string)
-	HasSupportedDeveloperSnses() bool
 	// GetDeveloperSnsCredentials() string
 	// GetDeveloperSnsCredentialsOk() (*string, bool)
 	// HasDeveloperSnsCredentials() bool

--- a/internal/provider/interface_utils.go
+++ b/internal/provider/interface_utils.go
@@ -32,7 +32,7 @@ func NewAPIClient(cfg interface{}) ClientWrapper {
 type stringTypes interface {
 	authlete.GrantType | authlete3.GrantType | authlete3.ResponseType | authlete.ResponseType |
 		authlete3.ServiceProfile | authlete.ServiceProfile | authlete3.ClaimType | authlete.ClaimType |
-		authlete3.Display | authlete.Display | authlete3.ClientAuthenticationMethod | authlete.ClientAuthenticationMethod |
+		authlete3.Display | authlete.Display | authlete3.ClientAuthMethod | authlete.ClientAuthenticationMethod |
 		authlete3.DeliveryMode | authlete.DeliveryMode | authlete3.AttachmentType | authlete.AttachmentType |
 		authlete3.ClientRegistrationType | authlete.ClientRegistrationType | string | authlete3.JwsAlg | authlete.JwsAlg |
 		authlete.JweAlg | authlete3.JweAlg | authlete3.ApplicationType | authlete.ApplicationType |

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -86,13 +86,17 @@ func testCreateTestService(t *testing.T, service2 IService) {
 	}
 	service2.SetApiKey(newService.GetApiKey())
 	if v3 {
-		service2.SetApiSecret(os.Getenv("AUTHLETE_SO_SECRET"))
+		service2.(*idp.Service).SetApiSecret(os.Getenv("AUTHLETE_SO_SECRET"))
 	} else {
-		service2.SetApiSecret(newService.GetApiSecret())
+		service2.(*authlete.Service).SetApiSecret(newService.(*authlete.Service).GetApiSecret())
 	}
 
 	_ = os.Setenv("AUTHLETE_API_KEY", strconv.FormatInt(service2.GetApiKey(), 10))
-	_ = os.Setenv("AUTHLETE_API_SECRET", service2.GetApiSecret())
+	if v3 {
+		_ = os.Setenv("AUTHLETE_API_SECRET", service2.(*idp.Service).GetApiSecret())
+	} else {
+		_ = os.Setenv("AUTHLETE_API_SECRET", service2.(*authlete.Service).GetApiSecret())
+	}
 
 	testAccProvider = New("dev")()
 
@@ -188,7 +192,7 @@ func pullServiceFromServer(s *terraform.State) (IService, error) {
 
 		if v3 {
 			auth := context.WithValue(context.Background(), authlete3.ContextAccessToken, client.serviceOwnerSecret)
-			response, _, err = client.authleteClient.v3.ServiceManagementApi.ServiceGetApi(auth, rs.Primary.ID).Execute()
+			response, _, err = client.authleteClient.v3.ServiceManagementAPI.ServiceGetApi(auth, rs.Primary.ID).Execute()
 		} else {
 			auth := context.WithValue(context.Background(), authlete.ContextBasicAuth, authlete.BasicAuth{
 				UserName: client.serviceOwnerKey,

--- a/internal/provider/service.go
+++ b/internal/provider/service.go
@@ -266,7 +266,7 @@ func serviceReadInternal(_ context.Context, d *schema.ResourceData, meta interfa
 
 	if v3 {
 		auth := context.WithValue(context.Background(), authlete3.ContextAccessToken, client.serviceOwnerSecret)
-		dto, _, err := client.authleteClient.v3.ServiceManagementApi.ServiceGetApi(auth, d.Id()).Execute()
+		dto, _, err := client.authleteClient.v3.ServiceManagementAPI.ServiceGetApi(auth, d.Id()).Execute()
 
 		if err != nil {
 			return diag.FromErr(err)
@@ -299,14 +299,14 @@ func serviceUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) 
 	if v3 {
 		auth := context.WithValue(context.Background(), authlete3.ContextAccessToken, client.serviceOwnerSecret)
 
-		srv, _, err := client.authleteClient.v3.ServiceManagementApi.ServiceGetApi(auth, d.Id()).Execute()
+		srv, _, err := client.authleteClient.v3.ServiceManagementAPI.ServiceGetApi(auth, d.Id()).Execute()
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
 		setDataToService(d, diags, srv)
 
-		srv, _, err = client.authleteClient.v3.ServiceManagementApi.ServiceUpdateApi(auth, d.Id()).Service(*srv).Execute()
+		srv, _, err = client.authleteClient.v3.ServiceManagementAPI.ServiceUpdateApi(auth, d.Id()).Service(*srv).Execute()
 
 		if err != nil {
 			return diag.FromErr(err)

--- a/internal/provider/serviceUtils.go
+++ b/internal/provider/serviceUtils.go
@@ -21,8 +21,8 @@ func dataToService(data *schema.ResourceData, diags diag.Diagnostics, newService
 	if NotZeroString(data, "description") {
 		newServiceDto.SetDescription(data.Get("description").(string))
 	}
-	if NotZeroNumber(data, "clients_per_developer") {
-		newServiceDto.SetClientsPerDeveloper(int32(data.Get("clients_per_developer").(int)))
+	if !v3 && NotZeroNumber(data, "clients_per_developer") {
+		newServiceDto.(*authlete.Service).SetClientsPerDeveloper(int32(data.Get("clients_per_developer").(int)))
 	}
 	newServiceDto.SetClientIdAliasEnabled(data.Get("client_id_alias_enabled").(bool))
 	if NotZeroArray(data, "attributes") {
@@ -52,14 +52,14 @@ func dataToService(data *schema.ResourceData, diags diag.Diagnostics, newService
 	if NotZeroArray(data, "supported_acrs") {
 		newServiceDto.SetSupportedAcrs(mapSetToString(data.Get("supported_acrs").(*schema.Set).List()))
 	}
-	if NotZeroString(data, "developer_authentication_callback_endpoint") {
-		newServiceDto.SetDeveloperAuthenticationCallbackEndpoint(data.Get("developer_authentication_callback_endpoint").(string))
+	if !v3 && NotZeroString(data, "developer_authentication_callback_endpoint") {
+		newServiceDto.(*authlete.Service).SetDeveloperAuthenticationCallbackEndpoint(data.Get("developer_authentication_callback_endpoint").(string))
 	}
-	if NotZeroString(data, "developer_authentication_callback_api_key") {
-		newServiceDto.SetDeveloperAuthenticationCallbackApiKey(data.Get("developer_authentication_callback_api_key").(string))
+	if !v3 && NotZeroString(data, "developer_authentication_callback_api_key") {
+		newServiceDto.(*authlete.Service).SetDeveloperAuthenticationCallbackApiKey(data.Get("developer_authentication_callback_api_key").(string))
 	}
-	if NotZeroString(data, "developer_authentication_callback_api_secret") {
-		newServiceDto.SetDeveloperAuthenticationCallbackApiSecret(data.Get("developer_authentication_callback_api_secret").(string))
+	if !v3 && NotZeroString(data, "developer_authentication_callback_api_secret") {
+		newServiceDto.(*authlete.Service).SetDeveloperAuthenticationCallbackApiSecret(data.Get("developer_authentication_callback_api_secret").(string))
 	}
 	if NotZeroArray(data, "supported_grant_types") {
 		if v3 {
@@ -149,7 +149,7 @@ func dataToService(data *schema.ResourceData, diags diag.Diagnostics, newService
 					mapListToDTO[string](data.Get("supported_token_auth_methods").(*schema.Set).List()))
 			case *authlete3.Service:
 				newServiceDto.(*authlete3.Service).SetSupportedTokenAuthMethods(
-					mapListToDTO[authlete3.ClientAuthenticationMethod](data.Get("supported_token_auth_methods").(*schema.Set).List()))
+					mapListToDTO[authlete3.ClientAuthMethod](data.Get("supported_token_auth_methods").(*schema.Set).List()))
 			}
 
 		} else {
@@ -174,7 +174,7 @@ func dataToService(data *schema.ResourceData, diags diag.Diagnostics, newService
 					mapListToDTO[string](data.Get("supported_revocation_auth_methods").(*schema.Set).List()))
 			case *authlete3.Service:
 				newServiceDto.(*authlete3.Service).SetSupportedRevocationAuthMethods(
-					mapListToDTO[authlete3.ClientAuthenticationMethod](data.Get("supported_revocation_auth_methods").(*schema.Set).List()))
+					mapListToDTO[authlete3.ClientAuthMethod](data.Get("supported_revocation_auth_methods").(*schema.Set).List()))
 			}
 		} else {
 			newServiceDto.(*authlete.Service).SetSupportedRevocationAuthMethods(
@@ -194,7 +194,7 @@ func dataToService(data *schema.ResourceData, diags diag.Diagnostics, newService
 					mapListToDTO[string](data.Get("supported_introspection_auth_methods").(*schema.Set).List()))
 			case *authlete3.Service:
 				newServiceDto.(*authlete3.Service).SetSupportedIntrospectionAuthMethods(
-					mapListToDTO[authlete3.ClientAuthenticationMethod](data.Get("supported_introspection_auth_methods").(*schema.Set).List()))
+					mapListToDTO[authlete3.ClientAuthMethod](data.Get("supported_introspection_auth_methods").(*schema.Set).List()))
 			}
 		} else {
 			newServiceDto.(*authlete.Service).SetSupportedIntrospectionAuthMethods(
@@ -554,8 +554,8 @@ func setDataToService(d *schema.ResourceData, diags diag.Diagnostics, srv IServi
 	if d.HasChange("description") {
 		srv.SetDescription(d.Get("description").(string))
 	}
-	if d.HasChange("clients_per_developer") {
-		srv.SetClientsPerDeveloper(int32(d.Get("clients_per_developer").(int)))
+	if !v3 && d.HasChange("clients_per_developer") {
+		srv.(*authlete.Service).SetClientsPerDeveloper(int32(d.Get("clients_per_developer").(int)))
 	}
 	if d.HasChange("client_id_alias_enabled") {
 		srv.SetClientIdAliasEnabled(d.Get("client_id_alias_enabled").(bool))
@@ -587,14 +587,14 @@ func setDataToService(d *schema.ResourceData, diags diag.Diagnostics, srv IServi
 	if d.HasChange("supported_acrs") {
 		srv.SetSupportedAcrs(mapSetToString(d.Get("supported_acrs").(*schema.Set).List()))
 	}
-	if d.HasChange("developer_authentication_callback_endpoint") {
-		srv.SetDeveloperAuthenticationCallbackEndpoint(d.Get("developer_authentication_callback_endpoint").(string))
+	if !v3 && d.HasChange("developer_authentication_callback_endpoint") {
+		srv.(*authlete.Service).SetDeveloperAuthenticationCallbackEndpoint(d.Get("developer_authentication_callback_endpoint").(string))
 	}
-	if d.HasChange("developer_authentication_callback_api_key") {
-		srv.SetDeveloperAuthenticationCallbackApiKey(d.Get("developer_authentication_callback_api_key").(string))
+	if !v3 && d.HasChange("developer_authentication_callback_api_key") {
+		srv.(*authlete.Service).SetDeveloperAuthenticationCallbackApiKey(d.Get("developer_authentication_callback_api_key").(string))
 	}
-	if d.HasChange("developer_authentication_callback_api_secret") {
-		srv.SetDeveloperAuthenticationCallbackApiSecret(d.Get("developer_authentication_callback_api_secret").(string))
+	if !v3 && d.HasChange("developer_authentication_callback_api_secret") {
+		srv.(*authlete.Service).SetDeveloperAuthenticationCallbackApiSecret(d.Get("developer_authentication_callback_api_secret").(string))
 	}
 	if d.HasChange("verified_claims_validation_schema_set") {
 		if v3 {
@@ -708,7 +708,7 @@ func setDataToService(d *schema.ResourceData, diags diag.Diagnostics, srv IServi
 			case *idp.Service:
 				srv.(*idp.Service).SetSupportedTokenAuthMethods(mapListToDTO[string](d.Get("supported_token_auth_methods").(*schema.Set).List()))
 			case *authlete3.Service:
-				srv.(*authlete3.Service).SetSupportedTokenAuthMethods(mapListToDTO[authlete3.ClientAuthenticationMethod](d.Get("supported_token_auth_methods").(*schema.Set).List()))
+				srv.(*authlete3.Service).SetSupportedTokenAuthMethods(mapListToDTO[authlete3.ClientAuthMethod](d.Get("supported_token_auth_methods").(*schema.Set).List()))
 			}
 
 		} else {
@@ -736,7 +736,7 @@ func setDataToService(d *schema.ResourceData, diags diag.Diagnostics, srv IServi
 			case *idp.Service:
 				srv.(*idp.Service).SetSupportedRevocationAuthMethods(mapListToDTO[string](d.Get("supported_revocation_auth_methods").(*schema.Set).List()))
 			case *authlete3.Service:
-				srv.(*authlete3.Service).SetSupportedRevocationAuthMethods(mapListToDTO[authlete3.ClientAuthenticationMethod](d.Get("supported_revocation_auth_methods").(*schema.Set).List()))
+				srv.(*authlete3.Service).SetSupportedRevocationAuthMethods(mapListToDTO[authlete3.ClientAuthMethod](d.Get("supported_revocation_auth_methods").(*schema.Set).List()))
 			}
 		} else {
 			srv.(*authlete.Service).SetSupportedRevocationAuthMethods(mapListToDTO[authlete.ClientAuthenticationMethod](d.Get("supported_revocation_auth_methods").(*schema.Set).List()))
@@ -754,7 +754,7 @@ func setDataToService(d *schema.ResourceData, diags diag.Diagnostics, srv IServi
 			case *idp.Service:
 				srv.(*idp.Service).SetSupportedIntrospectionAuthMethods(mapListToDTO[string](d.Get("supported_introspection_auth_methods").(*schema.Set).List()))
 			case *authlete3.Service:
-				srv.(*authlete3.Service).SetSupportedIntrospectionAuthMethods(mapListToDTO[authlete3.ClientAuthenticationMethod](d.Get("supported_introspection_auth_methods").(*schema.Set).List()))
+				srv.(*authlete3.Service).SetSupportedIntrospectionAuthMethods(mapListToDTO[authlete3.ClientAuthMethod](d.Get("supported_introspection_auth_methods").(*schema.Set).List()))
 			}
 		} else {
 			srv.(*authlete.Service).SetSupportedIntrospectionAuthMethods(mapListToDTO[authlete.ClientAuthenticationMethod](d.Get("supported_introspection_auth_methods").(*schema.Set).List()))
@@ -1152,12 +1152,14 @@ func serviceToResource(dto IService, data *schema.ResourceData) diag.Diagnostics
 
 	data.SetId(strconv.FormatInt(dto.GetApiKey(), 10))
 	if !v3 {
-		_ = data.Set("api_secret", dto.GetApiSecret())
+		_ = data.Set("api_secret", dto.(*authlete.Service).GetApiSecret())
 	}
 	_ = data.Set("service_name", dto.GetServiceName())
 	_ = data.Set("issuer", dto.GetIssuer())
 	_ = data.Set("description", dto.GetDescription())
-	_ = data.Set("clients_per_developer", dto.GetClientsPerDeveloper())
+	if !v3 {
+		_ = data.Set("clients_per_developer", dto.(*authlete.Service).GetClientsPerDeveloper())
+	}
 	_ = data.Set("client_id_alias_enabled", dto.GetClientIdAliasEnabled())
 	if v3 {
 		switch dto.(type) {
@@ -1225,9 +1227,11 @@ func serviceToResource(dto IService, data *schema.ResourceData) diag.Diagnostics
 	_ = data.Set("authentication_callback_api_key", dto.GetAuthenticationCallbackApiKey())
 	_ = data.Set("authentication_callback_api_secret", dto.GetAuthenticationCallbackApiSecret())
 	_ = data.Set("supported_acrs", mapSchemaFromString(dto.GetSupportedAcrs()))
-	_ = data.Set("developer_authentication_callback_endpoint", dto.GetDeveloperAuthenticationCallbackEndpoint())
-	_ = data.Set("developer_authentication_callback_api_key", dto.GetDeveloperAuthenticationCallbackApiKey())
-	_ = data.Set("developer_authentication_callback_api_secret", dto.GetDeveloperAuthenticationCallbackApiSecret())
+	if !v3 {
+		_ = data.Set("developer_authentication_callback_endpoint", dto.(*authlete.Service).GetDeveloperAuthenticationCallbackEndpoint())
+		_ = data.Set("developer_authentication_callback_api_key", dto.(*authlete.Service).GetDeveloperAuthenticationCallbackApiKey())
+		_ = data.Set("developer_authentication_callback_api_secret", dto.(*authlete.Service).GetDeveloperAuthenticationCallbackApiSecret())
+	}
 
 	_ = data.Set("supported_authorization_detail_types", mapSchemaFromString(dto.GetSupportedAuthorizationDetailsTypes()))
 	_ = data.Set("error_description_omitted", dto.GetErrorDescriptionOmitted())

--- a/internal/provider/service_crypto_test.go
+++ b/internal/provider/service_crypto_test.go
@@ -286,7 +286,7 @@ func findJWKStructure(s *terraform.State, kid string) (JWKStruct, error) {
 		if v3 {
 			auth := context.WithValue(context.Background(), authlete3.ContextAccessToken, client.serviceOwnerSecret)
 
-			response, _, err = client.authleteClient.v3.ServiceManagementApi.ServiceGetApi(auth, rs.Primary.ID).Execute()
+			response, _, err = client.authleteClient.v3.ServiceManagementAPI.ServiceGetApi(auth, rs.Primary.ID).Execute()
 		} else {
 			auth := context.WithValue(context.Background(), authlete.ContextBasicAuth, authlete.BasicAuth{
 				UserName: client.serviceOwnerKey,


### PR DESCRIPTION
## Summary

Updates the Authlete v3 SDK dependency from `github.com/authlete/openapi-for-go/v3 v3.0.0-alpha2` to `v3.0.3`.

Closes #191.

## Changes

- Update `github.com/authlete/openapi-for-go/v3` to `v3.0.3`
- Track generated SDK API changes, including:
  - `ClientManagementApi` to `ClientManagementAPI`
  - `ServiceManagementApi` to `ServiceManagementAPI`
  - v3 client management API argument order changes
  - v3 model field/type differences from the alpha SDK
- Keep v2-specific fields and methods on v2 model handling paths